### PR TITLE
Add configuration for performing Maven Central releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,13 @@ MicroShed Testing aims to:
 
 # How to use in an existing project:
 
-Add jitpack.io repository configuration to your pom.xml:
-```xml
-<repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-</repositories>
-```
-
-Then add `microshed-testing` and `junit-jupiter` as test-scoped dependencies:
+Add `microshed-testing` and `junit-jupiter` as test-scoped dependencies:
 ```xml
 <dependencies>
     <dependency>
-        <groupId>com.github.microshed.microshed-testing</groupId>
+        <groupId>org.microshed</groupId>
         <artifactId>microshed-testing-testcontainers</artifactId>
-        <version>0.4.1-beta</version>
+        <version>0.4.1</version>
        <scope>test</scope>
     </dependency>
     

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![MicroShed Testing](docs/images/MicroShed_Testing_slim.png)](http://microshed.org/microshed-testing)
 
-[![Jitpack](https://jitpack.io/v/microshed/microshed-testing.svg)](https://jitpack.io/#microshed/microshed-testing)
+[![Maven Central](https://img.shields.io/maven-central/v/org.microshed/microshed-testing-testcontainers.svg?label=Maven%20Central)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.microshed%22%20a%3A%22microshed-testing-testcontainers%22)
+[![Javadocs](https://www.javadoc.io/badge/org.microshed/microshed-testing-testcontainers.svg)](https://www.javadoc.io/doc/org.microshed/microshed-testing-testcontainers)
+[![Jitpack (Snapshots)](https://jitpack.io/v/microshed/microshed-testing.svg)](https://jitpack.io/#microshed/microshed-testing)
 [![Website](https://img.shields.io/website/http/microshed.org/microshed-testing?up_color=informational)](http://microshed.org/microshed-testing)
 [![Build Status](https://travis-ci.org/MicroShed/microshed-testing.svg?branch=master)](https://travis-ci.org/MicroShed/microshed-testing)
 [![License](https://img.shields.io/badge/License-ASL%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -19,7 +21,7 @@ MicroShed Testing aims to:
 
 # How to use in an existing project:
 
-Add `microshed-testing` and `junit-jupiter` as test-scoped dependencies:
+Add `microshed-testing-testcontainers` and `junit-jupiter` as test-scoped dependencies:
 ```xml
 <dependencies>
     <dependency>

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,10 @@
 subprojects {
     apply plugin: 'java'
+    
+    ext.publishScript = rootProject.rootDir.absolutePath + '/publish.gradle'
 
     group = 'org.microshed'
-    version = '0.1-SNAPSHOT'
+    version = '0.4.2-SNAPSHOT'
     
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
+ext.currentVersion = '0.4.2-SNAPSHOT'
+ext.lastRelease = '0.4.1'
+
 subprojects {
     apply plugin: 'java'
     
     ext.publishScript = rootProject.rootDir.absolutePath + '/publish.gradle'
 
     group = 'org.microshed'
-    version = '0.4.2-SNAPSHOT'
+    version = currentVersion
     
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -27,6 +30,33 @@ subprojects {
             showStackTraces = true
             exceptionFormat = 'full'
             events 'PASSED', 'FAILED', 'SKIPPED'
+        }
+    }
+}
+
+task updateVersion {
+    doLast {
+        if (!project.hasProperty('nextVersion'))
+            throw new GradleException("Must define '-PnextVersion=X.Y.Z' when running this task")
+        def isRelease = !nextVersion.endsWith('SNAPSHOT')
+
+        println 'Updating project version: ' + currentVersion + ' --> ' + nextVersion
+        ant.replaceregexp(match: currentVersion, replace: nextVersion, flags: 'g', byline: true) {
+            fileset(dir: '.', includes: '**/*.gradle')
+            fileset(dir: '.', includes: '**/pom.xml')
+        }
+
+        if (isRelease) {
+            println 'Updating doc version: ' + lastRelease + ' --> ' + nextVersion
+            ant.replaceregexp(match: lastRelease, replace: nextVersion, flags: 'g', byline: true) {
+                fileset(dir: '.', includes: '**/*.md')
+            }
+        } else {
+            // For non-release updates need to revert ext.lastRelease to a release version
+            ant.replaceregexp(match: "ext\\.lastRelease = '" + nextVersion, 
+                            replace: "ext\\.lastRelease = '" + lastRelease, flags: 'g', byline: true) {
+                fileset(dir: '.', includes: 'build.gradle')
+            }
         }
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,17 +1,5 @@
-plugins {
-    id 'maven-publish'
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'microshed-testing'
-            from components.java
-        }
-    }
-}
-
-description = "MicroShed Testing Framework"
+ext.title = "MicroShed Testing Framework"
+description = "A test framework for black-box testing MicroProfile and JavaEE applications"
 
 dependencies {
   compile group: 'javax.inject', name: 'javax.inject', version: '1'
@@ -24,3 +12,5 @@ dependencies {
   implementation group: 'org.glassfish', name: 'javax.json', version: '1.1.4'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.5.1'
 }
+
+apply from: publishScript

--- a/docs/features/00_Walkthrough.md
+++ b/docs/features/00_Walkthrough.md
@@ -56,23 +56,15 @@ It doesn't really matter what's in the Dockerfile. What matters is we can start 
 Given the above application code, we can start by adding maven dependencies:
 
 ```xml
-<repositories>
-    <!-- https://jitpack.io/#microshed/microshed-testing -->
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-</repositories>
-
 <dependencies>
     <dependency>
-        <groupId>com.github.microshed.microshed-testing</groupId>
+        <groupId>org.microshed</groupId>
         <artifactId>microshed-testing-testcontainers</artifactId>
-        <version>0.4.1-beta</version>
+        <version>0.4.1</version>
         <scope>test</scope>
     </dependency>
     
-    <!-- Any compatible version of JUnit Jupiter will work -->
+    <!-- Any compatible version of JUnit Jupiter 5.X will work -->
     <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,29 +114,17 @@ COPY src/main/liberty/config /config/
 
 ## Quick Start
 
-To get started writing a test with MicroShed Testing, add the following repository configuration to your pom.xml:
-
-```xml
-<repositories>
-    <!-- https://jitpack.io/#microshed/microshed-testing -->
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-</repositories>
-```
-
-Then add `system-test` and `junit-jupiter` as test-scoped dependencies:
+To get started writing a test with MicroShed Testing, add `system-test` and `junit-jupiter` as test-scoped dependencies:
 
 ```xml
 <dependency>
-    <groupId>com.github.microshed.microshed-testing</groupId>
+    <groupId>org.microshed</groupId>
     <artifactId>microshed-testing-testcontainers</artifactId>
-    <version>0.4.1-beta</version>
+    <version>0.4.1</version>
     <scope>test</scope>
 </dependency>
 
-<!-- Any compatible version of JUnit Jupiter will work -->
+<!-- Any compatible version of JUnit Jupiter 5.X will work -->
 <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter</artifactId>

--- a/modules/liberty/build.gradle
+++ b/modules/liberty/build.gradle
@@ -1,20 +1,10 @@
-plugins {
-    id 'maven-publish'
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'microshed-testing-liberty'
-            from components.java
-        }
-    }
-}
-
-description = "MicroShed Testing framework :: Liberty extensions"
+ext.title = "MicroShed Testing Framework :: Liberty extensions"
+description = "Extensions for using MicroShed Testing with Liberty servers"
 
 dependencies {
   compile project(':microshed-testing-testcontainers')
 }
+
+apply from: publishScript
 
 publishToMavenLocal.dependsOn ':microshed-testing-testcontainers:publishToMavenLocal'

--- a/modules/payara-micro/build.gradle
+++ b/modules/payara-micro/build.gradle
@@ -1,20 +1,10 @@
-plugins {
-    id 'maven-publish'
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'microshed-testing-payara-micro'
-            from components.java
-        }
-    }
-}
-
-description = "MicroShed Testing framework :: Payara Micro extensions"
+ext.title = "MicroShed Testing Framework :: Payara Micro extensions"
+description = "Extensions for using MicroShed Testing with Payara Micro servers"
 
 dependencies {
   compile project(':microshed-testing-testcontainers')
 }
+
+apply from: publishScript
 
 publishToMavenLocal.dependsOn ':microshed-testing-testcontainers:publishToMavenLocal'

--- a/modules/payara-server/build.gradle
+++ b/modules/payara-server/build.gradle
@@ -1,20 +1,10 @@
-plugins {
-    id 'maven-publish'
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'microshed-testing-payara-server'
-            from components.java
-        }
-    }
-}
-
-description = "MicroShed Testing framework :: Payara Server extensions"
+ext.title = "MicroShed Testing Framework :: Payara Server extensions"
+description = "Extensions for using MicroShed Testing with Payara servers"
 
 dependencies {
   compile project(':microshed-testing-testcontainers')
 }
+
+apply from: publishScript
 
 publishToMavenLocal.dependsOn ':microshed-testing-testcontainers:publishToMavenLocal'

--- a/modules/testcontainers/build.gradle
+++ b/modules/testcontainers/build.gradle
@@ -1,22 +1,12 @@
-plugins {
-    id 'maven-publish'
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'microshed-testing-testcontainers'
-            from components.java
-        }
-    }
-}
-
-description = "MicroShed Testing Framework :: Testcontainers extension"
+ext.title = "MicroShed Testing Framework :: Testcontainers extension"
+description = "Extensions for using MicroShed Testing with Testcontainers for managing application and resource lifecycle"
 
 dependencies {
   compile project(':microshed-testing-core')
   compile "org.testcontainers:junit-jupiter:1.12.1"
   testImplementation 'org.junit.jupiter:junit-jupiter:5.5.1'
 }
+
+apply from: publishScript
 
 publishToMavenLocal.dependsOn ':microshed-testing-core:publishToMavenLocal'

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,0 +1,78 @@
+apply plugin: 'maven-publish'
+
+ext.performRelease = !version.endsWith('SNAPSHOT')
+
+if (performRelease)
+    apply plugin: 'signing'
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    archiveClassifier = 'sources'
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    archiveClassifier = 'javadoc'
+}
+
+publishing {
+    if (performRelease) {
+        repositories {
+            maven {
+                url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                credentials {
+                    username ossrhUsername
+                    password ossrhPassword
+                }
+            }
+        }
+    } else {
+        repositories {
+            mavenLocal()
+        }
+    }
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = project.name
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            pom {
+                name = project.properties.title
+                description = project.description
+                url = 'https://microshed.org/microshed-testing/'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'aguibert'
+                        name = 'Andy Guibert'
+                        email = 'andy.guibert@gmail.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:ssh://git@github.com/MicroShed/microshed-testing.git'
+                    developerConnection = 'scm:git:ssh://git@github.com/MicroShed/microshed-testing.git'
+                    url = 'https://github.com/MicroShed/microshed-testing.git'
+                }
+            }
+        }
+    }
+}
+
+if (performRelease) {
+    signing {
+        sign publishing.publications.mavenJava
+    }
+}
+
+
+javadoc {
+    if(JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}

--- a/sample-apps/maven-app/build.gradle
+++ b/sample-apps/maven-app/build.gradle
@@ -10,10 +10,10 @@ task runMvnCompile(type:Exec) {
   environment System.getProperties()
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     executable "cmd"
-    args '/c', 'mvn', "clean", 'compile'
+    args '/c', 'mvn', "clean", 'compile', '-DprojectVersion=' + version
   } else {
     executable "mvn"
-    args 'clean', 'compile'
+    args 'clean', 'compile', '-DprojectVersion=' + version
   }
 }
 
@@ -22,10 +22,10 @@ task runMvnVerify(type:Exec) {
   environment System.getProperties()
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     executable "cmd"
-    args '/c', 'mvn', "clean", 'verify'
+    args '/c', 'mvn', "clean", 'verify', '-DprojectVersion=' + version
   } else {
     executable "mvn"
-    args 'clean', 'verify'
+    args 'clean', 'verify', '-DprojectVersion=' + version
   }
 }
 

--- a/sample-apps/maven-app/build.gradle
+++ b/sample-apps/maven-app/build.gradle
@@ -10,10 +10,10 @@ task runMvnCompile(type:Exec) {
   environment System.getProperties()
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     executable "cmd"
-    args '/c', 'mvn', "clean", 'compile', '-DprojectVersion=' + version
+    args '/c', 'mvn', "clean", 'compile'
   } else {
     executable "mvn"
-    args 'clean', 'compile', '-DprojectVersion=' + version
+    args 'clean', 'compile'
   }
 }
 
@@ -22,10 +22,10 @@ task runMvnVerify(type:Exec) {
   environment System.getProperties()
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     executable "cmd"
-    args '/c', 'mvn', "clean", 'verify', '-DprojectVersion=' + version
+    args '/c', 'mvn', "clean", 'verify'
   } else {
     executable "mvn"
-    args 'clean', 'verify', '-DprojectVersion=' + version
+    args 'clean', 'verify'
   }
 }
 

--- a/sample-apps/maven-app/pom.xml
+++ b/sample-apps/maven-app/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.microshed</groupId>
 			<artifactId>microshed-testing-testcontainers</artifactId>
-			<version>${projectVersion}</version>
+			<version>0.4.2-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/sample-apps/maven-app/pom.xml
+++ b/sample-apps/maven-app/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.microshed</groupId>
 			<artifactId>microshed-testing-testcontainers</artifactId>
-			<version>0.1-SNAPSHOT</version>
+			<version>${projectVersion}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Allows publishing to OSSRH staging using the command: `./gradlew publish`

Requirements for doing a publish:
- Version in root build.gradle file must not end with `SNAPSHOT`
- Must have `gpg` installed and configured with Gradle by adding this to `$GRADLE_HOME/gradle.properties`
```
signing.keyId=<GPG public key>
signing.password=<GPG password>
signing.secretKeyRingFile=/path/to/secring.gpg

ossrhUsername=<Sonatype username token>
ossrhPassword=<Sonatype password token>
```