### PR TITLE
Enhance withMpRestClient to account for configKey on MP Rest Client

### DIFF
--- a/core/src/main/java/org/microshed/testing/jupiter/MicroShedTestExtension.java
+++ b/core/src/main/java/org/microshed/testing/jupiter/MicroShedTestExtension.java
@@ -102,8 +102,10 @@ class MicroShedTestExtension implements BeforeAllCallback {
     @SuppressWarnings("unchecked")
     private static Optional<Class<? extends Annotation>> getMpRestClient() {
         try {
-            return Optional.of((Class<? extends Annotation>) Class.forName("org.eclipse.microprofile.rest.client.inject.RestClient"));
-        } catch (ClassNotFoundException e) {
+            return Optional.of((Class<? extends Annotation>) Class.forName("org.eclipse.microprofile.rest.client.inject.RestClient",
+                                                                           false,
+                                                                           MicroShedTestExtension.class.getClassLoader()));
+        } catch (ClassNotFoundException | LinkageError e) {
             return Optional.empty();
         }
     }

--- a/modules/testcontainers/build.gradle
+++ b/modules/testcontainers/build.gradle
@@ -4,6 +4,7 @@ description = "Extensions for using MicroShed Testing with Testcontainers for ma
 dependencies {
   compile project(':microshed-testing-core')
   compile 'org.testcontainers:junit-jupiter:1.12.4'
+  testCompile 'org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.3.4'
   testCompile 'org.slf4j:slf4j-log4j12:1.7.29'
   testCompile 'org.testcontainers:mockserver:1.12.3'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'

--- a/modules/testcontainers/src/test/java/org/microshed/testing/testcontainers/ApplicationContainerTest.java
+++ b/modules/testcontainers/src/test/java/org/microshed/testing/testcontainers/ApplicationContainerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 IBM Corporation and others
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.microshed.testing.testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.junit.jupiter.api.Test;
+import org.microshed.testing.testcontainers.config.TestServerAdapter;
+
+public class ApplicationContainerTest {
+
+    // Base uri configured with: com_example_StringRestClient_mp_rest_url
+    @RegisterRestClient
+    public static class SampleRestClient1 {
+    }
+
+    // Base uri configured with: rc_config_key_mp_rest_url
+    @RegisterRestClient(configKey = "rc-config-key")
+    public static class SampleRestClient2 {
+    }
+
+    // Base uri configured with: CLIENT_CONFIG_KEY_mp_rest_url
+    @RegisterRestClient(configKey = "CLIENT_CONFIG_KEY")
+    public static class SampleRestClient3 {
+    }
+
+    @Test
+    public void testMpRestClient() {
+        final String clientUrl = "http://example.com";
+
+        @SuppressWarnings("resource")
+        ApplicationContainer app = new ApplicationContainer("alpine:3.5")
+                        .withMpRestClient("com.example.StringRestClient", clientUrl)
+                        .withMpRestClient(SampleRestClient1.class, clientUrl)
+                        .withMpRestClient(SampleRestClient2.class, clientUrl)
+                        .withMpRestClient(SampleRestClient3.class, clientUrl);
+
+        Map<String, String> appEnv = app.getEnvMap();
+        assertEquals(clientUrl, appEnv.get("com_example_StringRestClient_mp_rest_url"));
+        assertEquals(clientUrl, appEnv.get("org_microshed_testing_testcontainers_ApplicationContainerTest_SampleRestClient1_mp_rest_url"));
+        assertEquals(clientUrl, appEnv.get("rc_config_key_mp_rest_url"));
+        assertEquals(clientUrl, appEnv.get("CLIENT_CONFIG_KEY_mp_rest_url"));
+    }
+
+    @Test
+    public void testCorrectServerAdapter() {
+        @SuppressWarnings("resource")
+        ApplicationContainer app = new ApplicationContainer("alpine:3.5");
+        assertEquals(TestServerAdapter.class, app.getServerAdapter().getClass());
+    }
+
+}


### PR DESCRIPTION
MicroProfile REST Client classes need to have a baseUri configured in order to use, and normally they are configured for different environments using the fqcn of the rest client class, with non alphanumeric characters replaced with `_`.

MP Rest Client 1.3 introduced a `configKey` attribute on the `@RegisterRestClient` annotation which allows a more concise configuration key to be used instead of the fqcn.

Update the `ApplicationContainer#withMpRestClient(Class<?>, String)` method to scan the provided MP Rest Client class to see if it has a `configKey` specified. If it does, set the configKey in the environment instead of the fqcn.