### PR TITLE
Integration with REST-assured

### DIFF
--- a/docs/features/14_RestAssured.md
+++ b/docs/features/14_RestAssured.md
@@ -1,0 +1,106 @@
+---
+layout: post
+title: "REST Assured"
+---
+
+MicroShed Testing provides auto-configuration for when [REST Assured](https://github.com/rest-assured/rest-assured) is available on the test classpath. REST Assured is a Java DSL library for easy testing of REST services. It is more verbose than using a REST client, but offers more direct control over the request and response.f
+
+## Enable REST Assured
+
+To enable REST Assured, add the following dependency to your pom.xml:
+
+```xml
+<dependency>
+    <groupId>io.rest-assured</groupId>
+    <artifactId>rest-assured</artifactId>
+    <version>4.2.0</version>
+    <scope>test</scope>
+</dependency>
+```
+
+Any version of REST Assured will have basic integration with MicroShed Testing -- the application URL and port will be auto-configured.
+
+As of REST Assured 4.2.0 or newer, a JSON-B based JSON ObjectMapper will be auto-configured.
+
+Because of the auto-configuration, no specific configuration is required in your test classes.
+
+## Example usage
+
+Validating a simple `GET` request:
+
+```java
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+// ...
+
+@MicroShedTest
+public class RestAssuredTest {
+
+    @Container
+    public static ApplicationContainer app = new ApplicationContainer()
+                    .withAppContextRoot("/myservice");
+
+    @Test
+    public void testCreatePerson() {
+        given()
+          .queryParam("name", "Hank")
+          .queryParam("age", 45)
+          .contentType(JSON)
+        .when()
+          .post("/")
+        .then()
+          .statusCode(200)
+          .contentType(JSON);
+    }
+}
+```
+
+It is also possible to send/receive POJOs with the JSON-B based ObjectMapper:
+
+```java
+    @Test
+    public void testGetPerson() {
+        // First create the Person
+        long bobId = given()
+                        .queryParam("name", "Bob")
+                        .queryParam("age", 24)
+                        .contentType(JSON)
+                     .when()
+                        .post("/")
+                     .then()
+                        .statusCode(200)
+                        .contentType(JSON)
+                     .extract()
+                        .as(long.class);
+                        
+        // Validate new created Person can be retrieved
+        Person bob = given()
+                        .pathParam("personId", bobId)
+                      .when()
+                        .get("/{personId}")
+                      .then()
+                        .statusCode(200)
+                        .contentType(JSON)
+                      .extract()
+                        .as(Person.class);
+        assertEquals("Bob", bob.name);
+        assertEquals(24, bob.age);
+        assertNotNull(bob.id);
+    }
+```
+
+For a complete working example, see the [RestAssuredTest class](https://github.com/MicroShed/microshed-testing/blob/master/sample-apps/everything-app/src/test/java/org/example/app/RestAssuredTest.java)
+
+## Auto-configuration override
+
+If you would like to use a different JSON ObjectMapper besides the default (JSON-B/Yasson), you can run the following code in your test initialization flow:
+
+```java
+import io.restassured.RestAssured;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.mapper.ObjectMapperType;
+// ...
+
+ObjectMapperConfig omConfig = ObjectMapperConfig.objectMapperConfig().defaultObjectMapperType(ObjectMapperType.JACKSON_2);
+RestAssured.config = RestAssured.config.objectMapperConfig(omConfig);
+```

--- a/docs/features/98_Examples.md
+++ b/docs/features/98_Examples.md
@@ -9,6 +9,7 @@ Sometimes code is worth a thousand words. Here are some pointers to working exam
 
 - [Basic JAX-RS application using Gradle](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/jaxrs-json)
 - [Basic JAX-RS application using Maven](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/maven-app)
+- [Basic JAX-RS application using REST Assured](https://github.com/MicroShed/microshed-testing/blob/master/sample-apps/everything-app/src/test/java/org/example/app/RestAssuredTest.java)
 - [JAX-RS and JDBC applicaiton using a PostgreSQL database](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/jdbc-app) 
 - [JAX-RS application secured with MP JWT](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/jaxrs-mpjwt)
 - [JAX-RS and MongoDB application that depends on an external REST service](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/everything-app)

--- a/sample-apps/everything-app/build.gradle
+++ b/sample-apps/everything-app/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.29'
   testCompile 'org.testcontainers:mockserver:1.12.3'
   testCompile 'org.mock-server:mockserver-client-java:5.5.4'
+  testCompile 'io.rest-assured:rest-assured:4.2.0'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'
 }
 

--- a/sample-apps/everything-app/src/test/java/org/example/app/RestAssuredTest.java
+++ b/sample-apps/everything-app/src/test/java/org/example/app/RestAssuredTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2020 IBM Corporation and others
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.example.app;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.microshed.testing.SharedContainerConfig;
+import org.microshed.testing.jupiter.MicroShedTest;
+
+@MicroShedTest
+@SharedContainerConfig(AppContainerConfig.class)
+public class RestAssuredTest {
+
+    @Test
+    public void testCreatePerson() {
+        // Verify POST /?name=Hank&age=45 returns HTTP 200
+        given()
+                        .queryParam("name", "Hank")
+                        .queryParam("age", 45)
+                        .contentType(JSON)
+                        .when()
+                        .post("/")
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON);
+    }
+
+    @Test
+    public void testMinSizeName() {
+        // First create a new person with min size name
+        long minSizeNameId = given()
+                        .queryParam("name", "Bob")
+                        .queryParam("age", 42)
+                        .contentType(JSON)
+                        .when()
+                        .post("/")
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON)
+                        .extract()
+                        .as(long.class);
+
+        // Verify they exist after creation
+        Person p = given()
+                        .pathParam("personId", minSizeNameId)
+                        .when()
+                        .get("/{personId}")
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON)
+                        .extract()
+                        .as(Person.class);
+        assertEquals("Bob", p.name);
+        assertEquals(42, p.age);
+        assertEquals(minSizeNameId, p.id);
+    }
+
+    @Test
+    public void testMinAge() {
+        long minAgeId = given()
+                        .queryParam("name", "Newborn")
+                        .queryParam("age", 0)
+                        .contentType(JSON)
+                        .when()
+                        .post("/")
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON)
+                        .extract()
+                        .as(long.class);
+
+        Person p = given()
+                        .pathParam("personId", minAgeId)
+                        .when()
+                        .get("/{personId}")
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON)
+                        .extract()
+                        .as(Person.class);
+        assertEquals("Newborn", p.name);
+        assertEquals(0, p.age);
+        assertEquals(minAgeId, p.id);
+    }
+
+    @Test
+    public void testGetPerson() {
+        // First create the Person
+        long bobId = given()
+                        .queryParam("name", "Bob")
+                        .queryParam("age", 24)
+                        .contentType(JSON)
+                        .when()
+                        .post("/")
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON)
+                        .extract()
+                        .as(long.class);
+
+        // Validate new created Person can be retrieved
+        Person bob = given()
+                        .pathParam("personId", bobId)
+                        .when()
+                        .get("/{personId}")
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON)
+                        .extract()
+                        .as(Person.class);
+        assertEquals("Bob", bob.name);
+        assertEquals(24, bob.age);
+        assertNotNull(bob.id);
+    }
+
+    @Test
+    public void testGetUnknownPerson() {
+        given()
+                        .pathParam("personId", -1L)
+                        .when()
+                        .get("/{personId}")
+                        .then()
+                        .statusCode(404);
+    }
+
+    @Test
+    public void testCreateBadPersonNullName() {
+        given()
+                        .queryParam("name", (Object[]) null)
+                        .queryParam("age", 5)
+                        .contentType(JSON)
+                        .when()
+                        .post("/")
+                        .then()
+                        .statusCode(400);
+    }
+
+    @Test
+    public void testCreateBadPersonNegativeAge() {
+        given()
+                        .queryParam("name", "NegativeAgePersoN")
+                        .queryParam("age", -1)
+                        .contentType(JSON)
+                        .when()
+                        .post("/")
+                        .then()
+                        .statusCode(400);
+    }
+
+    @Test
+    public void testCreateBadPersonNameTooLong() {
+        given()
+                        .queryParam("name", "NameTooLongPersonNameTooLongPersonNameTooLongPerson")
+                        .queryParam("age", 5)
+                        .contentType(JSON)
+                        .when()
+                        .post("/")
+                        .then()
+                        .statusCode(400);
+    }
+
+}


### PR DESCRIPTION
Add integration with REST-assured if it's on the classpath. This will save the user from needing to write the following code:
```java
RestAssured.baseURI = "http://" + app.getContainerIpAddress() + "/myservice";
RestAssured.basePath = "/myapp";
RestAssured.port = app.getFirstMappedPort();

RestAssured.config = RestAssured.config.objectMapperConfig(ObjectMapperConfig.objectMapperConfig()
                                    .defaultObjectMapperType(ObjectMapperType.JSONB));
```

This can't be merged yet because neither the `ObjectMapperType.JSONB` enum nor the `objectMapper(ObjectMapperType)` config methods exist yet, but I've proposed both to REST-assured in this PR: https://github.com/rest-assured/rest-assured/pull/1257