### PR TITLE
Make Kafka key/value [de]serializers optional with auto-detection

### DIFF
--- a/core/src/main/java/org/microshed/testing/jupiter/KafkaConfigAnnotationProcessor.java
+++ b/core/src/main/java/org/microshed/testing/jupiter/KafkaConfigAnnotationProcessor.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2020 IBM Corporation and others
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.microshed.testing.jupiter;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.microshed.testing.kafka.KafkaConsumerConfig;
+import org.microshed.testing.kafka.KafkaProducerConfig;
+
+class KafkaConfigAnnotationProcessor {
+
+    private final Map<Class<?>, String> defaultSerailizers = new HashMap<>();
+    private final Map<Class<?>, String> defaultDeserailizers = new HashMap<>();
+    private final String globalBootstrapServers = System.getProperty("org.microshed.kafka.bootstrap.servers");
+
+    KafkaConfigAnnotationProcessor() {
+        defaultSerailizers.put(byte[].class, "org.apache.kafka.common.serialization.ByteArraySerializer");
+        defaultSerailizers.put(ByteBuffer.class, "org.apache.kafka.common.serialization.ByteBufferSerializer");
+        defaultSerailizers.put(Double.class, "org.apache.kafka.common.serialization.DoubleSerializer");
+        defaultSerailizers.put(Float.class, "org.apache.kafka.common.serialization.FloatSerializer");
+        defaultSerailizers.put(Integer.class, "org.apache.kafka.common.serialization.IntegerSerializer");
+        defaultSerailizers.put(Long.class, "org.apache.kafka.common.serialization.LongSerializer");
+        defaultSerailizers.put(Short.class, "org.apache.kafka.common.serialization.ShortSerializer");
+        defaultSerailizers.put(String.class, "org.apache.kafka.common.serialization.StringSerializer");
+        defaultSerailizers.put(UUID.class, "org.apache.kafka.common.serialization.UUIDSerializer");
+
+        defaultDeserailizers.put(byte[].class, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        defaultDeserailizers.put(ByteBuffer.class, "org.apache.kafka.common.serialization.ByteBufferDeserializer");
+        defaultDeserailizers.put(Double.class, "org.apache.kafka.common.serialization.DoubleDeserializer");
+        defaultDeserailizers.put(Float.class, "org.apache.kafka.common.serialization.FloatDeserializer");
+        defaultDeserailizers.put(Integer.class, "org.apache.kafka.common.serialization.IntegerDeserializer");
+        defaultDeserailizers.put(Long.class, "org.apache.kafka.common.serialization.LongDeserializer");
+        defaultDeserailizers.put(Short.class, "org.apache.kafka.common.serialization.ShortDeserializer");
+        defaultDeserailizers.put(String.class, "org.apache.kafka.common.serialization.StringDeserializer");
+        defaultDeserailizers.put(UUID.class, "org.apache.kafka.common.serialization.UUIDDeserializer");
+    }
+
+    Properties getProducerProperties(Field producerField) {
+        KafkaProducerConfig producerConfig = producerField.getAnnotation(KafkaProducerConfig.class);
+        Properties properties = new Properties();
+        String bootstrapServers = producerConfig.bootstrapServers().isEmpty() ? globalBootstrapServers : producerConfig.bootstrapServers();
+        if (bootstrapServers.isEmpty())
+            throw new ExtensionConfigurationException("To use @KafkaProducerConfig on a KafkaProducer a bootstrap server must be " +
+                                                      "defined in the @KafkaProducerConfig annotation or using the " +
+                                                      "'org.microshed.kafka.bootstrap.servers' system property");
+        properties.put("bootstrap.servers", bootstrapServers);
+        if (isClassPropertySet(producerConfig.keySerializer().getName()))
+            properties.put("key.serializer", producerConfig.keySerializer().getName());
+        if (isClassPropertySet(producerConfig.valueSerializer().getName()))
+            properties.put("value.serializer", producerConfig.valueSerializer().getName());
+        for (String prop : producerConfig.properties()) {
+            int split = prop.indexOf("=");
+            if (split < 2)
+                throw new ExtensionConfigurationException("The property '" + prop + "' for field " + producerField + " must be in the format 'key=value'");
+            properties.put(prop.substring(0, split), prop.substring(split + 1));
+        }
+
+        // Auto-detect key/value serializers if needed
+        if (producerField.getGenericType() instanceof ParameterizedType) {
+            if (!properties.containsKey("key.serializer")) {
+                Type keyType = ((ParameterizedType) producerField.getGenericType()).getActualTypeArguments()[0];
+                if (defaultSerailizers.containsKey(keyType))
+                    properties.put("key.serializer", defaultSerailizers.get(keyType));
+            }
+            if (!properties.containsKey("value.serializer")) {
+                Type valueType = ((ParameterizedType) producerField.getGenericType()).getActualTypeArguments()[1];
+                if (defaultSerailizers.containsKey(valueType))
+                    properties.put("value.serializer", defaultSerailizers.get(valueType));
+            }
+        }
+
+        return properties;
+    }
+
+    Properties getConsumerProperties(Field consumerField) {
+        KafkaConsumerConfig consumerConfig = consumerField.getAnnotation(KafkaConsumerConfig.class);
+        Properties properties = new Properties();
+        String bootstrapServers = consumerConfig.bootstrapServers().isEmpty() ? globalBootstrapServers : consumerConfig.bootstrapServers();
+        if (bootstrapServers.isEmpty())
+            throw new ExtensionConfigurationException("To use @KafkaConsumerConfig on a KafkaConsumer a bootstrap server must be " +
+                                                      "defined in the @KafkaConsumerConfig annotation or using the " +
+                                                      "'org.microshed.kafka.bootstrap.servers' system property");
+        properties.put("bootstrap.servers", bootstrapServers);
+        properties.put("group.id", consumerConfig.groupId());
+        if (isClassPropertySet(consumerConfig.keyDeserializer().getName()))
+            properties.put("key.deserializer", consumerConfig.keyDeserializer().getName());
+        if (isClassPropertySet(consumerConfig.valueDeserializer().getName()))
+            properties.put("value.deserializer", consumerConfig.valueDeserializer().getName());
+        for (String prop : consumerConfig.properties()) {
+            int split = prop.indexOf("=");
+            if (split < 2)
+                throw new ExtensionConfigurationException("The property '" + prop + "' for field " + consumerField + " must be in the format 'key=value'");
+            properties.put(prop.substring(0, split), prop.substring(split + 1));
+        }
+
+        // Auto-detect key/value deserializer if needed
+        if (consumerField.getGenericType() instanceof ParameterizedType) {
+            if (!properties.containsKey("key.deserializer")) {
+                Type keyType = ((ParameterizedType) consumerField.getGenericType()).getActualTypeArguments()[0];
+                if (defaultDeserailizers.containsKey(keyType))
+                    properties.put("key.deserializer", defaultDeserailizers.get(keyType));
+            }
+            if (!properties.containsKey("value.deserializer")) {
+                Type valueType = ((ParameterizedType) consumerField.getGenericType()).getActualTypeArguments()[1];
+                if (defaultDeserailizers.containsKey(valueType))
+                    properties.put("value.deserializer", defaultDeserailizers.get(valueType));
+            }
+        }
+
+        return properties;
+    }
+
+    private static boolean isClassPropertySet(String prop) {
+        return !"java.lang.Object".equals(prop);
+    }
+
+}

--- a/core/src/main/java/org/microshed/testing/kafka/KafkaConsumerConfig.java
+++ b/core/src/main/java/org/microshed/testing/kafka/KafkaConsumerConfig.java
@@ -45,13 +45,17 @@ public @interface KafkaConsumerConfig {
 
     /**
      * @return Sets the <code>key.deserializer</code> property for the injected <code>KafkaConsumer</code>.
+     *         If unset, an an attempt will be made to select an appropriate class from the built-in deserializers
+     *         in the <code>org.apache.kafka.common.serialization</code> package.
      */
-    Class<?> keyDeserializer();
+    Class<?> keyDeserializer() default Object.class;
 
     /**
      * @return Sets the <code>value.deserializer</code> property for the injected <code>KafkaConsumer</code>.
+     *         If unset, an an attempt will be made to select an appropriate class from the built-in deserializers
+     *         in the <code>org.apache.kafka.common.serialization</code> package.
      */
-    Class<?> valueDeserializer();
+    Class<?> valueDeserializer() default Object.class;
 
     /**
      * @return Sets the <code>group.id</code> property for the injected <code>KafkaConsumer</code>.

--- a/core/src/main/java/org/microshed/testing/kafka/KafkaProducerConfig.java
+++ b/core/src/main/java/org/microshed/testing/kafka/KafkaProducerConfig.java
@@ -45,13 +45,17 @@ public @interface KafkaProducerConfig {
 
     /**
      * @return Sets the <code>key.serializer</code> property for the injected <code>KafkaProducer</code>.
+     *         If unset, an an attempt will be made to select an appropriate class from the built-in serializers
+     *         in the <code>org.apache.kafka.common.serialization</code> package.
      */
-    Class<?> keySerializer();
+    Class<?> keySerializer() default Object.class;
 
     /**
      * @return Sets the <code>value.serializer</code> property for the injected <code>KafkaProducer</code>.
+     *         If unset, an an attempt will be made to select an appropriate class from the built-in serializers
+     *         in the <code>org.apache.kafka.common.serialization</code> package.
      */
-    Class<?> valueSerializer();
+    Class<?> valueSerializer() default Object.class;
 
     /**
      * @return An optional array of <code>key=value</code> strings, which will be used as configuration options

--- a/docs/features/KafkaMessaging.md
+++ b/docs/features/KafkaMessaging.md
@@ -57,14 +57,11 @@ import org.microshed.testing.kafka.KafkaProducerConfig;
 @SharedContainerConfig(AppContainerConfig.class)
 public class KitchenEndpointIT {
 
-  @KafkaProducerConfig(keySerializer = StringSerializer.class,      // (1)
-                       valueSerializer = StringSerializer.class)
+  @KafkaProducerConfig                                   // (1)
   public static KafkaProducer<String, String> producer;
 
-  @KafkaConsumerConfig(keyDeserializer = StringDeserializer.class, 
-                       valueDeserializer = StringDeserializer.class, 
-                       groupId = "update-status", 
-                       topics = "statusTopic")                      // (2)
+  @KafkaConsumerConfig(groupId = "update-status",
+                       topics = "statusTopic")           // (2)
   public static KafkaConsumer<String, String> consumer;
   
   @Test
@@ -79,8 +76,9 @@ public class KitchenEndpointIT {
 }
 ```
 
-1. Each `@KafkaProducerConfig` and `@KafkaConsumerConfig` must define a set of key/value [de]serializers
-that correspond to the key/value types defined in the `KafkaProducer` and `KafkaConsumer`.
+1. Each `@KafkaProducerConfig` and `@KafkaConsumerConfig` may optionally define a set of key/value [de]serializers
+that correspond to the key/value types defined in the `KafkaProducer` and `KafkaConsumer`. If none are specified,
+then an attempt will be made to auto-detect a fitting built-in [de]serializer.
 2. For `@KafkaConsumerConfig` zero or more `topics` may be specified to automatically subscribe the 
 injected `consumer` to the specified `topics`.
 

--- a/sample-apps/kafka-app/src/test/java/org/example/app/KitchenEndpointIT.java
+++ b/sample-apps/kafka-app/src/test/java/org/example/app/KitchenEndpointIT.java
@@ -28,8 +28,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.example.app.KitchenOrder.JsonbSerializer;
 import org.example.app.KitchenOrder.KitchenOrderDeserializer;
 import org.junit.jupiter.api.Test;
@@ -42,10 +40,10 @@ import org.microshed.testing.kafka.KafkaProducerConfig;
 @SharedContainerConfig(AppContainerConfig.class)
 public class KitchenEndpointIT {
 
-  @KafkaProducerConfig(keySerializer = StringSerializer.class, valueSerializer = JsonbSerializer.class)
+  @KafkaProducerConfig(valueSerializer = JsonbSerializer.class)
   public static KafkaProducer<String, KitchenOrder> producer;
 
-  @KafkaConsumerConfig(keyDeserializer = StringDeserializer.class, valueDeserializer = KitchenOrderDeserializer.class, 
+  @KafkaConsumerConfig(valueDeserializer = KitchenOrderDeserializer.class, 
       groupId = "update-status", topics = "statusTopic", 
       properties = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "=earliest")
   public static KafkaConsumer<String, KitchenOrder> consumer;


### PR DESCRIPTION
Improves the initial Kafka auto-configuration done in #159 by checking the key/value types on injected `KafkaProducer<K,V>` and `KafkaConsumer<K,V>` types.

The following K/V types have built-in serialization and can be auto-detected:
- byte[]
- ByteBuffer
- Double
- Float
- Integer
- Long
- Short
- String
- UUID

For example, previously the required config for a producer would be:
```java
  @KafkaProducerConfig(keySerializer = StringSerializer.class, 
                       valueSerializer = StringSerializer.class)
  public static KafkaProducer<String,String> producer;
```
and now it there is no required config:
```java
  @KafkaProducerConfig
  public static KafkaProducer<String,String> producer;
```