### PR TITLE
Doc typos, minor fixes

### DIFF
--- a/docs/features/ApplicationEnvironment.md
+++ b/docs/features/ApplicationEnvironment.md
@@ -51,7 +51,7 @@ The envionment is called "hollow" because everything _except_ your application w
                     .withNetworkAliases("testmongo");
 ```
 
-With the default `TestcontainersConfiguration`, both the `app` and `mongo` containers would be started each time tests are run. With "hollow" mode, only the `mongo` container would be started each time the tests run, and instead of staring the `app` container the already-running application runtime will be used.
+With the default `TestcontainersConfiguration`, both the `app` and `mongo` containers would be started each time tests are run. With "hollow" mode, only the `mongo` container would be started each time the tests run, and instead of starting the `app` container the already-running application runtime will be used.
 
 This environment is also provided by the `microshed-testing-testcontainers` module. To enable this environment, the following system properties or env vars must be set:
 * **microshed_hostname**: Indicates the hostname or IP address where the application is running. For example, `localhost` or `216.3.128.12`.

--- a/docs/features/Examples.md
+++ b/docs/features/Examples.md
@@ -10,7 +10,7 @@ Sometimes code is worth a thousand words. Here are some pointers to working exam
 
 - [Basic JAX-RS application using Gradle](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/jaxrs-json)
 - [Basic JAX-RS application using Maven](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/maven-app)
-- [Basic JAX-RS application using REST Assured](https://github.com/MicroShed/microshed-testing/blob/master/sample-apps/everything-app/src/test/java/org/example/app/RestAssuredTest.java)
+- [Basic JAX-RS application using REST Assured](https://github.com/MicroShed/microshed-testing/blob/master/sample-apps/everything-app/src/test/java/org/example/app/RestAssuredIT.java)
 - [JAX-RS and JDBC application using a PostgreSQL database](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/jdbc-app)
 - [JAX-RS application secured with Basic Auth](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/jaxrs-basicauth) 
 - [JAX-RS application secured with MP JWT](https://github.com/MicroShed/microshed-testing/tree/master/sample-apps/jaxrs-mpjwt)

--- a/docs/features/MP_JWT.md
+++ b/docs/features/MP_JWT.md
@@ -34,7 +34,7 @@ public class SecuredService {
 }
 ```
 
-As the `@RolesAllowed` annotations imply, anyone can access the `GET /data/ping` endpoint, but only client authenticated in the `users` role can access the `GET /data/users` endpoint.
+As the `@RolesAllowed` annotations imply, anyone can access the `GET /data/ping` endpoint, but only clients authenticated in the `users` role can access the `GET /data/users` endpoint.
 
 ## Testing a MP JWT secured endpoint
 

--- a/docs/features/RestAssured.md
+++ b/docs/features/RestAssured.md
@@ -4,7 +4,7 @@ title: "REST Assured"
 order: 14
 ---
 
-MicroShed Testing provides auto-configuration for when [REST Assured](https://github.com/rest-assured/rest-assured) is available on the test classpath. REST Assured is a Java DSL library for easy testing of REST services. It is more verbose than using a REST client, but offers more direct control over the request and response.f
+MicroShed Testing provides auto-configuration for when [REST Assured](https://github.com/rest-assured/rest-assured) is available on the test classpath. REST Assured is a Java DSL library for easy testing of REST services. It is more verbose than using a REST client, but offers more direct control over the request and response.
 
 ## Enable REST Assured
 
@@ -90,7 +90,7 @@ It is also possible to send/receive POJOs with the JSON-B based ObjectMapper:
     }
 ```
 
-For a complete working example, see the [RestAssuredTest class](https://github.com/MicroShed/microshed-testing/blob/master/sample-apps/everything-app/src/test/java/org/example/app/RestAssuredTest.java)
+For a complete working example, see the [RestAssuredTest class](https://github.com/MicroShed/microshed-testing/blob/master/sample-apps/everything-app/src/test/java/org/example/app/RestAssuredIT.java)
 
 ## Auto-configuration override
 

--- a/docs/features/SharedContainerConfiguration.md
+++ b/docs/features/SharedContainerConfiguration.md
@@ -78,7 +78,7 @@ The Testcontainers API has a built-in dependency mechanism which can be used to 
 ```
 
 Since the `app` container `dependsOn` the `mongo` container, when MicroShed Testing starts the containers, the Testcontainers library will
-ensure that the `mongo` container starts sucessfully before the `app` container start is initiatied. 
+ensure that the `mongo` container starts sucessfully before the `app` container start is initiated. 
 
 ### Fully custom start process
 

--- a/docs/features/Walkthrough.md
+++ b/docs/features/Walkthrough.md
@@ -6,7 +6,7 @@ order: 00
 
 Have you ever toiled with creating mock objects for unit tests? How about custom setup steps for integration tests? Ever had an issue in production because of differences in behavior between testing and production environments?
 
-One of the great benefits of Docker is that we get a nice consistent package that contains everything down to the OS, meaning it’s portable to any hardware. Great, so lets use this to get consistent testing environments too!
+One of the great benefits of Docker is that we get a nice consistent package that contains everything down to the OS, meaning it's portable to any hardware. Great, so let's use this to get consistent testing environments too!
 
 # Starting application
 
@@ -167,7 +167,7 @@ A few questions may come up at this point, such as:
 ### Why port 33735?
 
 Although port 33735 was not configured anywhere, MicroShed Testing still waited for this port to be available. This is because the application is running inside a container, and the ports inside containers can be mapped to different ports outside of the container. Testcontainers takes advantage of this 
-feature of containers by automatically randomizing the ports so they do not conflict. In th is case, port `9080` inside of the container was randomly exposed as `33735`, which can be obtained by calling `app.getFirstExposedPort()` or `app.getMappedPort(9080)`.
+feature of containers by automatically randomizing the ports so they do not conflict. In this case, port `9080` inside of the container was randomly exposed as `33735`, which can be obtained by calling `app.getFirstExposedPort()` or `app.getMappedPort(9080)`.
 
 ### Why wasn't the URL accessible?
 
@@ -181,7 +181,7 @@ However, our application does not respond at this endpoint, so we need to config
 	                .withReadinessPath("/myservice/people");
 ```
 
-Alternatively, if your application runtime supports MicroProfile Health 2.0, it will have a standard readiness endpoint at `/heath/ready`, which will return `HTTP 200` when the application is available.
+Alternatively, if your application runtime supports MicroProfile Health 2.0, it will have a standard readiness endpoint at `/health/ready`, which will return `HTTP 200` when the application is available.
 
 ## Writing your first test method
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,5 +166,5 @@ public class MyTest {
 }
 ```
 
-For a more complete introduction, see the [Walkthrough page](Walkthrough).
+For a more complete introduction, see the [Walkthrough page](https://microshed.org/microshed-testing/features/Walkthrough.html)
 


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

First commit is self-explanatory.

For [second commit](https://github.com/MicroShed/microshed-testing/pull/210/commits/50a590775f2c9eac405085a6d131f6a60884c13b), I didn't want to use a relative link and have it not work on the website.. so just added an absolute link. 