### PR TITLE
Reintroduce "Prepare for next release 0.9.3"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add `microshed-testing-testcontainers` and `junit-jupiter` as test-scoped depend
     <dependency>
         <groupId>org.microshed</groupId>
         <artifactId>microshed-testing-testcontainers</artifactId>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
        <scope>test</scope>
     </dependency>
     
@@ -37,6 +37,34 @@ Add `microshed-testing-testcontainers` and `junit-jupiter` as test-scoped depend
     </dependency>
 
     <!-- other dependencies... -->
+</dependencies>
+```
+
+## How to test a Java EE application
+
+Add `microshed-testing-core` as a test-scoped dependency:
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.microshed</groupId>
+        <artifactId>microshed-testing-core</artifactId>
+        <version>0.9.2</version>
+       <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+## How to test a Jakarta EE application
+
+Add `microshed-testing-core-jakarta` as a test-scoped dependency:
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.microshed</groupId>
+        <artifactId>microshed-testing-core-jakarta</artifactId>
+        <version>0.9.2</version>
+       <scope>test</scope>
+    </dependency>
 </dependencies>
 ```
 
@@ -59,7 +87,7 @@ NOTE: The first run will take longer due to downloading required container layer
 NOTE: If a container is consistantly timing out on your system you can set a longer timeout (in seconds) with the system property
 `microshed.testing.startup.timeout` default value is 60 seconds.
 
-NOTE: If a mockserver has started, but HTTP calls are consistantly timint out on your system you can set a longer timeout (in milliseconds)
+NOTE: If a mockserver has started, but HTTP calls are consistantly timing out on your system you can set a longer timeout (in milliseconds)
 with the system property `mockserver.maxSocketTimeout` default value is 120000 milliseconds.
 
 ### Tested with:

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ plugins {
     // to check for updates run: ./gradlew dependencyUpdates -Drevision=release
     id 'com.github.ben-manes.versions' version '0.50.0'
 }
-ext.currentVersion = '0.9.2-SNAPSHOT'
-ext.lastRelease = '0.9.1'
+ext.currentVersion = '0.9.3-SNAPSHOT'
+ext.lastRelease = '0.9.2'
 
 subprojects {
     apply plugin: 'java'

--- a/core/src/main/java/org/microshed/testing/jaxrs/RestClientBuilder.java
+++ b/core/src/main/java/org/microshed/testing/jaxrs/RestClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 IBM Corporation and others
+ * Copyright (c) 2019, 2023 IBM Corporation and others
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -110,6 +110,8 @@ public class RestClientBuilder {
     }
 
     /**
+     * @param key The header key
+     * @param value The header value
      * @return The same builder instance
      */
     public RestClientBuilder withHeader(String key, String value) {

--- a/docs/features/SupportedRuntimes.md
+++ b/docs/features/SupportedRuntimes.md
@@ -12,7 +12,7 @@ Maven Dependency:
 <dependency>
     <groupId>org.microshed</groupId>
     <artifactId>microshed-testing-liberty</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ Maven Dependency:
 <dependency>
     <groupId>org.microshed</groupId>
     <artifactId>microshed-testing-payara-micro</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
 </dependency>
 ```
 
@@ -52,7 +52,7 @@ Maven Dependency:
 <dependency>
     <groupId>org.microshed</groupId>
     <artifactId>microshed-testing-payara-server</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ Maven Dependency:
 <dependency>
     <groupId>org.microshed</groupId>
     <artifactId>microshed-testing-wildfly</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ Maven Dependency:
 <dependency>
     <groupId>org.microshed</groupId>
     <artifactId>microshed-testing-quarkus</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
 </dependency>
 ```
 

--- a/docs/features/Walkthrough.md
+++ b/docs/features/Walkthrough.md
@@ -61,7 +61,14 @@ Given the above application code, we can start by adding maven dependencies:
     <dependency>
         <groupId>org.microshed</groupId>
         <artifactId>microshed-testing-testcontainers</artifactId>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
+        <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+        <groupId>org.microshed</groupId>
+        <artifactId>microshed-testing-core-jakarta</artifactId>
+        <version>0.9.2</version>
         <scope>test</scope>
     </dependency>
     

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,14 @@ To get started writing a test with MicroShed Testing, add `system-test` and `jun
 <dependency>
     <groupId>org.microshed</groupId>
     <artifactId>microshed-testing-testcontainers</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
+    <scope>test</scope>
+</dependency>
+
+<dependency>
+    <groupId>org.microshed</groupId>
+    <artifactId>microshed-testing-core-jakarta</artifactId>
+    <version>0.9.2</version>
     <scope>test</scope>
 </dependency>
 

--- a/sample-apps/maven-app/pom.xml
+++ b/sample-apps/maven-app/pom.xml
@@ -34,13 +34,13 @@
 		<dependency>
 			<groupId>org.microshed</groupId>
 			<artifactId>microshed-testing-testcontainers</artifactId>
-			<version>0.9.2-SNAPSHOT</version>
+			<version>0.9.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.microshed</groupId>
 			<artifactId>microshed-testing-core</artifactId>
-			<version>0.9.2-SNAPSHOT</version>
+			<version>0.9.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/sample-apps/quarkus-app/pom.xml
+++ b/sample-apps/quarkus-app/pom.xml
@@ -87,13 +87,13 @@
     <dependency>
       <groupId>org.microshed</groupId>
       <artifactId>microshed-testing-quarkus</artifactId>
-      <version>0.9.2-SNAPSHOT</version>
+      <version>0.9.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.microshed</groupId>
       <artifactId>microshed-testing-core-jakarta</artifactId>
-      <version>0.9.2-SNAPSHOT</version>
+      <version>0.9.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Reverts MicroShed/microshed-testing#342
Reintroduces #339 

Had to revert since our publish build still needs to run.
I should have marked the PR as draft so it didn't get merged.
