### PR TITLE
Update dependabot for gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,17 @@ updates:
       interval: daily
 
   - package-ecosystem: gradle
-    directory: /
+    directory: /core
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gradle
+    directory: /modules
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gradle
+    directory: /sample-apps
     schedule:
       interval: daily
 


### PR DESCRIPTION
Dependabot is not correctly scanning gradle dependencies within nested directories.
I'm hoping prompting dependabot to look closer at the top level directories will get it to start scanning. 