### PR TITLE
Updates Jekyll to 4.3.3

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.9.0"
+gem "jekyll", "~> 4.3.3"
 
 gem 'jekyll-feed'
 


### PR DESCRIPTION
I'm using Renovate to update my forked MicroShed testing repo. I'm much more happy with Renovate than Dependabot. There is a PR opened in my fork, to update Jekyll from 3.9.0 to 4.3.3, as reflected in this pr. However, the log of renovate shows to following. I'm not sure wether this is the correct way to Upgrade Jekyll, so please advice.

⚠ Artifact update problem
Renovate failed to update an artifact related to this branch. You probably do not want to merge this PR as-is.

♻ Renovate will retry this branch, including artifacts, only when one of the following happens:

any of the package files in this branch needs updating, or
the branch becomes conflicted, or
you click the rebase/retry checkbox if found above, or
you rename this PR's title to start with "rebase!" to trigger it manually
The artifact failure details are included below:

File name: docs/Gemfile.lock
[14:23:45.366] INFO (253): Installing tool bundler@2.0.1...
[14:23:45.379] INFO (253): tool already installed
    tool: "bundler"
[14:23:45.549] FATAL (253): Command failed with exit code 1: bundler --version
    err: {
      "type": "Error",
      "message": "Command failed with exit code 1: bundler --version",
      "stack":
          Error: Command failed with exit code 1: bundler --version
              at makeError (/snapshot/dist/containerbase-cli.js:44223:13)
              at handlePromise (/snapshot/dist/containerbase-cli.js:45122:29)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
              at async InstallBundlerService.test (/snapshot/dist/containerbase-cli.js:51776:5)
              at async InstallToolService.linkAndTest (/snapshot/dist/containerbase-cli.js:52087:7)
              at async InstallToolService.execute (/snapshot/dist/containerbase-cli.js:52034:11)
              at async InstallToolShortCommand.execute (/snapshot/dist/containerbase-cli.js:52222:14)
              at async InstallToolShortCommand.validateAndExecute (/snapshot/dist/containerbase-cli.js:2426:26)
              at async _Cli.run (/snapshot/dist/containerbase-cli.js:3539:22)
              at async _Cli.runExit (/snapshot/dist/containerbase-cli.js:3547:28)
      "shortMessage": "Command failed with exit code 1: bundler --version",
      "command": "bundler --version",
      "escapedCommand": "bundler --version",
      "exitCode": 1,
      "cwd": "/tmp/renovate/repos/github/appiepollo14/microshed-testing/docs",
      "failed": true,
      "timedOut": false,
      "isCanceled": false,
      "killed": false
    }
[14:23:45.663] INFO (253): Installed tool bundler with errors in 297ms.

/opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/shared_helpers.rb:272:in `search_up': undefined method `untaint' for "/tmp/renovate/repos/github/appiepollo14/microshed-testing/docs":String (NoMethodError)

      current  = File.expand_path(SharedHelpers.pwd).untaint
                                                    ^^^^^^^^
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/shared_helpers.rb:259:in `find_file'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/shared_helpers.rb:251:in `find_gemfile'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/shared_helpers.rb:27:in `root'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler.rb:234:in `root'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler.rb:246:in `app_config_path'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler.rb:273:in `settings'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/feature_flag.rb:21:in `block in settings_method'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/cli.rb:97:in `<class:CLI>'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/cli.rb:7:in `<module:Bundler>'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/cli.rb:6:in `<top (required)>'
	from <internal:/opt/containerbase/tools/ruby/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/opt/containerbase/tools/ruby/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/exe/bundle:23:in `block in <top (required)>'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/exe/bundle:22:in `<top (required)>'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/exe/bundler:4:in `load'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/gems/bundler-2.0.1/exe/bundler:4:in `<top (required)>'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/bin/bundler:25:in `load'
	from /opt/containerbase/tools/bundler/2.0.1/3.2/bin/bundler:25:in `<main>'