### PR TITLE
Upgrade quarkus dependencies

### DIFF
--- a/.github/workflows/microshed-ci.yml
+++ b/.github/workflows/microshed-ci.yml
@@ -36,11 +36,15 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # v3.0.0
+        with:
+          cache-overwrite-existing: true
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }} #Read only for pulls, read/write for pushes
       - name: Build with Gradle
         run: |
           chmod +x gradlew
-          ./gradlew assemble testClasses
+          ./gradlew assemble testClasses --parallel
   integration_tests:
     name: Tests - ${{matrix.category}}
     runs-on: ubuntu-latest
@@ -78,7 +82,11 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # v3.0.0
+        with:
+          cache-overwrite-existing: true
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }} #Read only for pulls, read/write for pushes
       - uses: testspace-com/setup-testspace@ee1482f978eb5010ec27b6f6372904f01f2edd68 # v1.0.6
         if: ${{ github.event_name == 'push' }}
         with:
@@ -90,10 +98,9 @@ jobs:
           CATEGORY: ${{matrix.category}}
         run: |
           chmod +x gradlew
-          echo "org.gradle.daemon=false" >> gradle.properties
 
           mkdir results
-  
+
           echo "Will be running projects $TEST_PROJECTS"
           for TEST_PROJECT in $TEST_PROJECTS
           do
@@ -116,7 +123,7 @@ jobs:
             fi
 
           done
-  
+
           echo "Done running all tests, results folder contains:"
           ls -la results/
       - name: Upload test results

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,2 @@
-org.gradle.parallel=false
-org.gradle.caching=true
 # See: https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true
-

--- a/modules/quarkus/build.gradle
+++ b/modules/quarkus/build.gradle
@@ -2,7 +2,8 @@ ext.title = "MicroShed Testing Framework :: Quarkus extensions"
 description = "Extensions for using MicroShed Testing with Quarkus"
 
 dependencies {
-  api 'io.quarkus:quarkus-junit5:3.6.6'
+  //Cannot upgrade past 3.6.9 without increasing project to Java 17
+  api 'io.quarkus:quarkus-junit5:3.6.9'
   api project(':microshed-testing-testcontainers')
 }
 

--- a/sample-apps/quarkus-app/pom.xml
+++ b/sample-apps/quarkus-app/pom.xml
@@ -18,9 +18,10 @@
 
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.8</quarkus.platform.version>
+    <!-- Cannot upgrade past 3.6.9 without increasing project to Java 17 -->
+    <quarkus.platform.version>3.6.9</quarkus.platform.version>
 
-    <quarkus-plugin.version>3.6.6</quarkus-plugin.version>
+    <quarkus-plugin.version>3.6.9</quarkus-plugin.version>
     <surefire-plugin.version>3.2.5</surefire-plugin.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Upgrading quarkus dependencies without dependabot due to new versions of quarkus being compiled at java 17.
Also experimented with getting out builds to execute faster.
Went from [6m 57s ](https://github.com/MicroShed/microshed-testing/actions/runs/7919427925?pr=502)-> [4m 17s](https://github.com/MicroShed/microshed-testing/actions/runs/7920022004?pr=502)
Should get better once the gradle cache is populated