### PR TITLE
chore: Replace deprecated Gradle action with its successor.

### DIFF
--- a/.github/workflows/microshed-ci.yml
+++ b/.github/workflows/microshed-ci.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
         with:
           cache-overwrite-existing: true
           cache-read-only: ${{ github.ref != 'refs/heads/main' }} #Read only for pulls, read/write for pushes
@@ -83,7 +83,7 @@ jobs:
           java-version: 11
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
         with:
           cache-overwrite-existing: true
           cache-read-only: ${{ github.ref != 'refs/heads/main' }} #Read only for pulls, read/write for pushes


### PR DESCRIPTION
See: https://github.com/gradle/actions/blob/v4.1.0/docs/deprecation-upgrade-guide.md for more information