### PR TITLE
Add Java 17 to the CI build and test matrix (towards #401)

### DIFF
--- a/.github/workflows/microshed-ci.yml
+++ b/.github/workflows/microshed-ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 11 ]
+        java: [ 11, 17 ]
       fail-fast: false
       max-parallel: 4
     
@@ -46,7 +46,7 @@ jobs:
           chmod +x gradlew
           ./gradlew assemble testClasses --parallel
   integration_tests:
-    name: Tests - ${{matrix.category}}
+    name: Tests - ${{matrix.category}}, Java ${{matrix.java}}
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
@@ -54,6 +54,7 @@ jobs:
       fail-fast: false
       max-parallel: 18
       matrix:
+        java: [ 11, 17 ]
         include:
           - category: GENERAL
             projects: >
@@ -80,7 +81,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0

--- a/modules/testcontainers/?/.testcontainers.properties
+++ b/modules/testcontainers/?/.testcontainers.properties
@@ -1,0 +1,3 @@
+#Modified by Testcontainers
+#Fri Jun 12 21:25:34 UTC 2026
+docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy


### PR DESCRIPTION
Towards #401.

## What this does

Adds **Java 17 to the CI matrix** — both the build job (`java: [ 11, 17 ]`) and all five integration-test categories (new `java` axis, de-hardcoded `setup-java`) — so the project builds and is fully tested on 17 alongside 11.

## What this deliberately does NOT do

It does **not** raise `source`/`targetCompatibility` (still 11). Following the concern raised in the issue discussion (building *with* 17 while raising the artifact floor would narrow the user base — as discussed in #401), the bytecode floor stays where it is; raising it remains a 1.0.0 decision for the maintainers. If/when you take it, this matrix is already in place to test it.

Mapping to the issue checklist:
- "If necessary upgrade gradle wrapper" — not necessary: the wrapper is already Gradle 8.5, which runs fine on 17.
- "Update build.gradle / sample-apps poms (source/target)" — intentionally left at 11 per the floor discussion above.
- "Update CI Workflow to build and run using Java 17" — this PR.
- "Update documentation" — found no JDK-requirement statements in the repo docs that need changing; happy to add one if you'd like a supported-JDKs note somewhere specific.

## Verification

Locally (Temurin 11 and 17, Docker available for Testcontainers): `gradlew build -x integrationTest` for `core` and all six framework modules — green on both JDKs, all unit tests passing (including the Testcontainers-backed configuration tests). The sample-app integration-test categories are exactly what the new CI axis runs.

